### PR TITLE
Update version to 1.2.7

### DIFF
--- a/includes/WC_Reepay_Renewals.php
+++ b/includes/WC_Reepay_Renewals.php
@@ -231,7 +231,7 @@ class WC_Reepay_Renewals {
         if ( $data['event_type'] == 'invoice_authorized' || $data['event_type'] == 'invoice_settled' ) {
             $order = rp_get_order_by_handle( $data['invoice'] );
         } elseif ( $data['event_type'] == 'customer_payment_method_added' ) {
-            $order = rp_get_order_by_session( $data['payment_method_reference'] );
+            $order = rp_get_order_by_session( $data['payment_method_reference'], $data['customer'] );
         } else {
             return;
         }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, subscriptions, ecommerce, e-commerce, commerce
 Requires at least: 5.5
 Tested up to: 6.5.3
 Requires PHP: 7.4
-Stable tag: 1.2.6
+Stable tag: 1.2.7
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -63,6 +63,10 @@ Standard Billwerk+ Optimize features:
 3. For correct plugin operation install and activate Billwerk+ Pay for WooCommerce. API keys for both plugins should be the same.
 
 == Changelog ==
+v 1.2.7 -
+* [Fix] - Missing payment_method_reference data in the Billwerk+ customer_payment_method_added webhook could cause PHP fatal error. Subscriptions would not be created when this happened.
+* [Compatibility] - Billwerk+ Pay version 1.7.7
+
 v 1.2.6 - 
 * [Improvement] Product name change to "Billwerk+ Subscriptions" to "Billwerk+ Optimize".
 * [Fix] - Subscription variable product coming in as regular orders.

--- a/reepay-subscriptions-for-woocommerce.php
+++ b/reepay-subscriptions-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Get all the advanced subscription features from Billwerk+ Optimize while still keeping your usual WooCommerce tools. The Billwerk+ Optimize for WooCommerce plugins gives you the best prerequisites to succeed with your subscription business.
  * Author: Billwerk+
  * Author URI: https://www.billwerk.plus/
- * Version: 1.2.6
+ * Version: 1.2.7
  * Text Domain: reepay-subscriptions-for-woocommerce
  * Domain Path: /languages
  * WC requires at least: 3.0.0


### PR DESCRIPTION
[Fix] - Missing payment_method_reference data in the Billwerk+ customer_payment_method_added webhook could cause PHP fatal error. Subscriptions would not be created when this happened.
[Compatibility] - Billwerk+ Pay version 1.7.7