### PR TITLE
v 1.3.6

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,6 +1,14 @@
 jQuery(function ($) {
     const $body = $('body');
 
+    if (window.reepay && window.reepay.nonce) {
+        $.ajaxSetup({
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
+            }
+        });
+    }
+
     var linksToMenu = $('a[href="admin.php?page=reepay-subscriptions-for-woocommerce"]');
     linksToMenu.attr("href", "https://admin.billwerk.plus/#/rp/subscriptions")
     linksToMenu.attr("target", "_blank")
@@ -61,6 +69,9 @@ jQuery(function ($) {
                 $.ajax({
                     url: window.reepay.rest_urls.get_addon + window.reepay.query_string + `amount=true&handle=${addon_field.val()}`,
                     method: 'GET',
+                    beforeSend: function (xhr) {
+                        xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
+                    },
                     success: function (response_data) {
                         if (!response_data && !response_data.success) {
                             console.log(response_data);
@@ -111,7 +122,7 @@ jQuery(function ($) {
                 url,
                 method: 'GET',
                 beforeSend: function (xhr) {
-
+                    xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
                 },
                 success: function (response_data) {
                     if (!response_data.success) {
@@ -158,7 +169,7 @@ jQuery(function ($) {
                 url,
                 method: 'GET',
                 beforeSend: function (xhr) {
-
+                    xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
                 },
                 success: function (response_data) {
                     if (!response_data.success) {
@@ -482,7 +493,7 @@ jQuery(function ($) {
             url,
             method: 'GET',
             beforeSend: function (xhr) {
-
+                xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
             },
             success: function (response_data) {
                 if (!response_data.success) {
@@ -530,7 +541,7 @@ jQuery(function ($) {
             url: window.reepay.rest_urls.get_coupon + window.reepay.query_string + `handle=${handle}`,
             method: 'GET',
             beforeSend: function (xhr) {
-
+                xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
             },
             success: function (response_data) {
                 if (!response_data.success) {
@@ -556,8 +567,13 @@ jQuery(function ($) {
             return;
         }
         
-        $.get(window.reepay.rest_urls.get_discount + window.reepay.query_string + `handle=${handle}`)
-            .then(function (response_data) {
+        $.ajax({
+            url: window.reepay.rest_urls.get_discount + window.reepay.query_string + `handle=${handle}`,
+            method: 'GET',
+            beforeSend: function (xhr) {
+                xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
+            },
+        }).then(function (response_data) {
                 if (!response_data.success) {
                     return;
                 }
@@ -614,7 +630,7 @@ jQuery(function ($) {
             url,
             method: 'GET',
             beforeSend: function (xhr) {
-
+                xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
             },
             success: function (response_data) {
                 if (!response_data.success) {
@@ -666,7 +682,7 @@ jQuery(function ($) {
                 url,
                 method: 'GET',
                 beforeSend: function (xhr) {
-
+                    xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
                 },
                 success: function (response_data) {
                     if (!response_data.success) {
@@ -708,7 +724,7 @@ jQuery(function ($) {
                 url,
                 method: 'GET',
                 beforeSend: function (xhr) {
-
+                    xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
                 },
                 success: function (response_data) {
                     if (!response_data.success) {

--- a/includes/WC_Reepay_Discounts_And_Coupons.php
+++ b/includes/WC_Reepay_Discounts_And_Coupons.php
@@ -319,6 +319,11 @@ class WC_Reepay_Discounts_And_Coupons
 
     function save_coupon_text_field($post_id, WC_Coupon $coupon)
     {
+        // Security: Check user capability
+        if ( ! current_user_can( 'edit_shop_coupons' ) ) {
+            return;
+        }
+
         $type = $coupon->get_discount_type();
 
         if ($type !== 'reepay_type') {
@@ -343,11 +348,20 @@ class WC_Reepay_Discounts_And_Coupons
 
         $data = array_merge($data, $couponData);
 
-
-        if ($_REQUEST['use_existing_discount'] === 'true') {
-            $discountData = static::get_existing_discount(sanitize_text_field($_REQUEST['_reepay_discount_use_existing_discount_id']));
-            update_post_meta($post_id, '_reepay_discount_handle', $discountData['discount_handle']);
-            $data = array_merge($data, $discountData);
+        // Security: Improved validation for existing discount
+        $use_existing = isset( $_REQUEST['use_existing_discount'] ) && $_REQUEST['use_existing_discount'] === 'true';
+        if ( $use_existing ) {
+            $discount_id = isset( $_REQUEST['_reepay_discount_use_existing_discount_id'] ) 
+                ? sanitize_text_field( wp_unslash( $_REQUEST['_reepay_discount_use_existing_discount_id'] ) ) 
+                : '';
+            
+            if ( ! empty( $discount_id ) ) {
+                $discountData = static::get_existing_discount( $discount_id );
+                if ( ! empty( $discountData ) ) {
+                    update_post_meta($post_id, '_reepay_discount_handle', $discountData['discount_handle']);
+                    $data = array_merge($data, $discountData);
+                }
+            }
         }
 
         $data['_reepay_discount_name'] = isset($_REQUEST['_reepay_discount_name']) ? sanitize_text_field($_REQUEST['_reepay_discount_name']) : '';

--- a/includes/WC_Reepay_Discounts_And_Coupons.php
+++ b/includes/WC_Reepay_Discounts_And_Coupons.php
@@ -324,6 +324,12 @@ class WC_Reepay_Discounts_And_Coupons
             return;
         }
 
+        // Security: Verify nonce
+        if ( ! isset( $_POST['woocommerce_meta_nonce'] ) || 
+             ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
+            return;
+        }
+
         $type = $coupon->get_discount_type();
 
         if ($type !== 'reepay_type') {

--- a/includes/WC_Reepay_Discounts_And_Coupons.php
+++ b/includes/WC_Reepay_Discounts_And_Coupons.php
@@ -325,7 +325,15 @@ class WC_Reepay_Discounts_And_Coupons
             return;
         }
 
-        $data = $_REQUEST;
+        $data = array();
+        // Safely populate $data from $_REQUEST by sanitizing each field
+        foreach ( $_REQUEST as $key => $value ) {
+            if ( is_array( $value ) ) {
+                $data[ $key ] = array_map( 'sanitize_text_field', wp_unslash( $value ) );
+            } else {
+                $data[ $key ] = sanitize_text_field( wp_unslash( $value ) );
+            }
+        }
 
         $couponData = static::get_existing_coupon(sanitize_text_field($_REQUEST['_reepay_discount_use_existing_coupon_id']));
 

--- a/includes/WC_Reepay_Renewals.php
+++ b/includes/WC_Reepay_Renewals.php
@@ -102,7 +102,7 @@ class WC_Reepay_Renewals {
         $subscriptions_in_cart = $this->reepay_cart_subscription_count();
 
         //filter reepay type subscriptions
-        if ( empty( $subscriptions_in_cart ) && ( ! isset( $_GET['order_id'] ) || ! $this->reepay_order_contains_subscription( $_GET['order_id'] ) ) ) {
+        if ( empty( $subscriptions_in_cart ) && ( ! isset( $_GET['order_id'] ) || ! $this->reepay_order_contains_subscription( absint( $_GET['order_id'] ) ) ) ) {
             return $available_gateways;
         }
 

--- a/includes/WC_Reepay_Subscription_Addons_Rest.php
+++ b/includes/WC_Reepay_Subscription_Addons_Rest.php
@@ -21,8 +21,8 @@ class WC_Reepay_Subscription_Addons_Rest extends WC_Reepay_Subscription_Plan_Sim
 			$addons = WC_Reepay_Subscription_Addons::get_reepay_addons_list( false, true );
 
 			foreach ( $addons['content'] ?? [] as $addon ) {
-				$html .= '<option value="' . $addon['handle'] . '" ' . selected( $addon['handle'], $request['handle'],
-						false ) . '>' . esc_attr( $addon['name'] ) . '</option>';
+				$html .= '<option value="' . esc_attr( $addon['handle'] ) . '" ' . selected( $addon['handle'], $request['handle'],
+						false ) . '>' . esc_html( $addon['name'] ) . '</option>';
 			}
 
 			return new WP_REST_Response( [

--- a/includes/WC_Reepay_Subscription_Coupons_Rest.php
+++ b/includes/WC_Reepay_Subscription_Coupons_Rest.php
@@ -21,7 +21,7 @@ class WC_Reepay_Subscription_Coupons_Rest extends WC_Reepay_Subscription_Plan_Si
 			$addons = WC_Reepay_Discounts_And_Coupons::get_coupons();
 
 			foreach ( $addons ?? [] as $addon ) {
-				$html .= '<option value="' . $addon['handle'] . '">' . esc_attr( $addon['name'] ) . '</option>';
+				$html .= '<option value="' . esc_attr( $addon['handle'] ) . '">' . esc_html( $addon['name'] ) . '</option>';
 			}
 
 			return new WP_REST_Response( [

--- a/includes/WC_Reepay_Subscription_Plan_Simple.php
+++ b/includes/WC_Reepay_Subscription_Plan_Simple.php
@@ -669,14 +669,14 @@ class WC_Reepay_Subscription_Plan_Simple {
 
 		if ( ! empty( $_POST['_reepay_subscription_customer_role'] ) && $_POST['_reepay_subscription_customer_role'] !== 'without_changes' ) {
 			update_post_meta( $post_id, '_reepay_subscription_customer_role',
-				$_POST['_reepay_subscription_customer_role'] );
+				sanitize_text_field( wp_unslash( $_POST['_reepay_subscription_customer_role'] ) ) );
 		} else {
 			delete_post_meta( $post_id, '_reepay_subscription_customer_role' );
 		}
 
 		if ( ! empty( $_POST['_reepay_subscription_customer_role_expired'] ) && $_POST['_reepay_subscription_customer_role_expired'] !== 'without_changes' ) {
 			update_post_meta( $post_id, '_reepay_subscription_customer_role_expired',
-				$_POST['_reepay_subscription_customer_role_expired'] );
+				sanitize_text_field( wp_unslash( $_POST['_reepay_subscription_customer_role_expired'] ) ) );
 		} else {
 			delete_post_meta( $post_id, '_reepay_subscription_customer_role_expired' );
 		}
@@ -687,7 +687,7 @@ class WC_Reepay_Subscription_Plan_Simple {
 	}
 
 	public function is_reepay_product_saving() {
-		return ! empty( $_REQUEST ) && ! empty( $_REQUEST['product-type'] ) && $_REQUEST['product-type'] == 'reepay_simple_subscriptions';
+		return ! empty( $_REQUEST ) && ! empty( $_REQUEST['product-type'] ) && $_REQUEST['product-type'] === 'reepay_simple_subscriptions';
 	}
 
 	/**

--- a/includes/WC_Reepay_Subscription_Plan_Simple_Rest.php
+++ b/includes/WC_Reepay_Subscription_Plan_Simple_Rest.php
@@ -26,7 +26,9 @@ class WC_Reepay_Subscription_Plan_Simple_Rest extends WP_REST_Controller {
 		register_rest_route( $this->namespace, $this->rest_base, [
 			"methods"             => WP_REST_Server::READABLE,
 			"callback"            => array( $this, "get_item" ),
-			"permission_callback" => '__return_true',
+			"permission_callback" => function () {
+				return current_user_can( 'manage_woocommerce' );
+			},
 			"args"                => array(
 				"handle" => array(
 					"type"              => "string",

--- a/includes/WC_Reepay_Subscription_Plan_Variable.php
+++ b/includes/WC_Reepay_Subscription_Plan_Variable.php
@@ -101,14 +101,14 @@ class WC_Reepay_Subscription_Plan_Variable extends WC_Reepay_Subscription_Plan_S
 
 		if ( ! empty( $_POST['_reepay_subscription_customer_role'][ $i ] ) && $_POST['_reepay_subscription_customer_role'][ $i ] !== 'without_changes' ) {
 			update_post_meta( $post_id, '_reepay_subscription_customer_role',
-				$_POST['_reepay_subscription_customer_role'][ $i ] );
+				sanitize_text_field( wp_unslash( $_POST['_reepay_subscription_customer_role'][ $i ] ) ) );
 		} else {
 			delete_post_meta( $post_id, '_reepay_subscription_customer_role' );
 		}
 
 		if ( ! empty( $_POST['_reepay_subscription_customer_role_expired'][ $i ] ) && $_POST['_reepay_subscription_customer_role_expired'][ $i ] !== 'without_changes' ) {
 			update_post_meta( $post_id, '_reepay_subscription_customer_role_expired',
-				$_POST['_reepay_subscription_customer_role_expired'][ $i ] );
+				sanitize_text_field( wp_unslash( $_POST['_reepay_subscription_customer_role_expired'][ $i ] ) ) );
 		} else {
 			delete_post_meta( $post_id, '_reepay_subscription_customer_role_expired' );
 		}
@@ -125,7 +125,7 @@ class WC_Reepay_Subscription_Plan_Variable extends WC_Reepay_Subscription_Plan_S
 	public function is_reepay_product_saving() {
 		return ! empty( $_REQUEST ) &&
 		       ! empty( $_REQUEST['product-type'] ) &&
-		       $_REQUEST['product-type'] == 'reepay_variable_subscriptions' &&
+		       $_REQUEST['product-type'] === 'reepay_variable_subscriptions' &&
 		       ! empty( $_REQUEST['_reepay_subscription_handle'] );
 	}
 

--- a/includes/import/WC_Reepay_Import_AJAX.php
+++ b/includes/import/WC_Reepay_Import_AJAX.php
@@ -67,6 +67,11 @@ class WC_Reepay_Import_AJAX {
 	 * AJAX handler to get objects that can be imported
 	 */
 	public function get_objects() {
+		// Security: Check user capability
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( 'Unauthorized', 403 );
+		}
+
 		$this->check_nonce();
 
 		$result            = [];
@@ -92,6 +97,11 @@ class WC_Reepay_Import_AJAX {
 	 * AJAX handler to save objects from request
 	 */
 	public function save_objects() {
+		// Security: Check user capability
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( 'Unauthorized', 403 );
+		}
+
 		$this->check_nonce();
 
 		$res = [];

--- a/includes/import/WC_Reepay_Import_AJAX.php
+++ b/includes/import/WC_Reepay_Import_AJAX.php
@@ -67,7 +67,7 @@ class WC_Reepay_Import_AJAX {
 	 * AJAX handler to get objects that can be imported
 	 */
 	public function get_objects() {
-		$this->chech_nonce();
+		$this->check_nonce();
 
 		$result            = [];
 		$objects_to_import = $this->get_objects_to_import_from_get();
@@ -92,7 +92,7 @@ class WC_Reepay_Import_AJAX {
 	 * AJAX handler to save objects from request
 	 */
 	public function save_objects() {
-		$this->chech_nonce();
+		$this->check_nonce();
 
 		$res = [];
 
@@ -101,10 +101,12 @@ class WC_Reepay_Import_AJAX {
 				continue;
 			}
 
+			$selected = array_map( 'sanitize_text_field', wp_unslash( $_POST['selected'][ $object ] ) );
+
 			$objects_data = call_user_func( "WC_Reepay_Import::get_reepay_$object", [ 'all' ] );
 
 			if ( ! empty( $objects_data ) ) {
-				$res[ $object ] = call_user_func( "WC_Reepay_Import::import_$object", $objects_data, $_POST['selected'][ $object ] );
+				$res[ $object ] = call_user_func( "WC_Reepay_Import::import_$object", $objects_data, $selected );
 			}
 		}
 
@@ -142,11 +144,19 @@ class WC_Reepay_Import_AJAX {
 	}
 
 	/**
-	 * Prevent AJAX request if nonce fails check
+	 * Prevent AJAX request if nonce fails check or user lacks permissions
 	 *
 	 * @return true
 	 */
-	public function chech_nonce() {
+	public function check_nonce() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error(
+				[
+					'error' => __( 'You do not have permission to perform this action.', 'reepay-subscriptions-for-woocommerce' ),
+				]
+			);
+		}
+
 		if ( ! check_ajax_referer( self::$ajax_nonce, 'nonce', false ) ) {
 			wp_send_json_error(
 				[
@@ -156,5 +166,12 @@ class WC_Reepay_Import_AJAX {
 		}
 
 		return true;
+	}
+
+	/**
+	 * @deprecated Use check_nonce() instead.
+	 */
+	public function chech_nonce() {
+		return $this->check_nonce();
 	}
 }

--- a/includes/import/WC_Reepay_Import_AJAX.php
+++ b/includes/import/WC_Reepay_Import_AJAX.php
@@ -80,7 +80,24 @@ class WC_Reepay_Import_AJAX {
 
 		foreach ( array_keys( WC_Reepay_Import::$import_objects ) as $object ) {
 			if ( ! empty( $objects_to_import[ $object ] ) ) {
-				$res = call_user_func( "WC_Reepay_Import::get_reepay_$object", $objects_to_import[ $object ], $debug );
+				// Security: Use switch instead of call_user_func
+				switch ( $object ) {
+					case 'plans':
+						$res = WC_Reepay_Import::get_reepay_plans( $objects_to_import[ $object ], $debug );
+						break;
+					case 'addons':
+						$res = WC_Reepay_Import::get_reepay_addons( $objects_to_import[ $object ], $debug );
+						break;
+					case 'coupons':
+						$res = WC_Reepay_Import::get_reepay_coupons( $objects_to_import[ $object ], $debug );
+						break;
+					case 'discounts':
+						$res = WC_Reepay_Import::get_reepay_discounts( $objects_to_import[ $object ], $debug );
+						break;
+					default:
+						wp_send_json_error( 'Invalid object type' );
+						return;
+				}
 
 				if ( is_wp_error( $res ) ) {
 					wp_send_json_error( $res );
@@ -113,10 +130,39 @@ class WC_Reepay_Import_AJAX {
 
 			$selected = array_map( 'sanitize_text_field', wp_unslash( $_POST['selected'][ $object ] ) );
 
-			$objects_data = call_user_func( "WC_Reepay_Import::get_reepay_$object", [ 'all' ] );
+			// Security: Use switch instead of call_user_func
+			switch ( $object ) {
+				case 'plans':
+					$objects_data = WC_Reepay_Import::get_reepay_plans( [ 'all' ] );
+					break;
+				case 'addons':
+					$objects_data = WC_Reepay_Import::get_reepay_addons( [ 'all' ] );
+					break;
+				case 'coupons':
+					$objects_data = WC_Reepay_Import::get_reepay_coupons( [ 'all' ] );
+					break;
+				case 'discounts':
+					$objects_data = WC_Reepay_Import::get_reepay_discounts( [ 'all' ] );
+					break;
+				default:
+					continue 2;
+			}
 
 			if ( ! empty( $objects_data ) ) {
-				$res[ $object ] = call_user_func( "WC_Reepay_Import::import_$object", $objects_data, $selected );
+				switch ( $object ) {
+					case 'plans':
+						$res[ $object ] = WC_Reepay_Import::import_plans( $objects_data, $selected );
+						break;
+					case 'addons':
+						$res[ $object ] = WC_Reepay_Import::import_addons( $objects_data, $selected );
+						break;
+					case 'coupons':
+						$res[ $object ] = WC_Reepay_Import::import_coupons( $objects_data, $selected );
+						break;
+					case 'discounts':
+						$res[ $object ] = WC_Reepay_Import::import_discounts( $objects_data, $selected );
+						break;
+				}
 			}
 		}
 

--- a/includes/my-account/WC_Reepay_My_Account_Payment_Method.php
+++ b/includes/my-account/WC_Reepay_My_Account_Payment_Method.php
@@ -8,15 +8,15 @@ class WC_Reepay_My_Account_Payment_Method {
 	}
 
 	public function add_subscription_arg( $url ) {
-		if ( $_GET['reepay_subscription'] ) {
-			$url = sanitize_url( add_query_arg( 'reepay_subscription', $_GET['reepay_subscription'], $url ) );
+		if ( ! empty( $_GET['reepay_subscription'] ) ) {
+			$url = sanitize_url( add_query_arg( 'reepay_subscription', sanitize_text_field( wp_unslash( $_GET['reepay_subscription'] ) ), $url ) );
 		}
 
 		return $url;
 	}
 
 	public function payment_method_added( WC_Payment_Token $token ) {
-		$handle = sanitize_text_field( $_GET['reepay_subscription'] ) ?? '';
+		$handle = isset( $_GET['reepay_subscription'] ) ? sanitize_text_field( wp_unslash( $_GET['reepay_subscription'] ) ) : '';
 
 		if ( ! empty( $handle ) ) {
 			try {

--- a/includes/my-account/WC_Reepay_My_Account_Payment_Methods_Actions.php
+++ b/includes/my-account/WC_Reepay_My_Account_Payment_Methods_Actions.php
@@ -27,7 +27,7 @@ class WC_Reepay_My_Account_Payment_Methods_Actions {
 
 		wc_nocache_headers();
 
-		if ( get_current_user_id() !== $token->get_user_id() || ! isset( $_REQUEST['_wpnonce'] ) || false === wp_verify_nonce( wp_unslash( $_REQUEST['_wpnonce'] ), 'delete-payment-method-' . $token_id ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( get_current_user_id() !== $token->get_user_id() || ! isset( $_GET['_wpnonce'] ) || false === wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'delete-payment-method' ) ) {
 			wc_add_notice( __( 'Invalid payment method.', 'reepay-checkout-gateway' ), 'error' );
 		} else {
 			$deleted = false;

--- a/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
+++ b/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
@@ -18,7 +18,12 @@ class WC_Reepay_My_Account_Subscription_Actions {
 		if ( ! isset( $_GET['reepay_subscriptions_action'] ) ) {
 			return;
 		}
-		
+
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'reepay_subscription_action' ) ) {
+			wc_add_notice( __( 'Security check failed. Please try again.', 'reepay-subscriptions-for-woocommerce' ), 'error' );
+			return;
+		}
+
 		foreach ( $this->subscription_actions as $subscription_action ) {
 			if ( empty( $_GET[ $subscription_action ] ) ) {
 				continue;
@@ -69,8 +74,9 @@ class WC_Reepay_My_Account_Subscription_Actions {
 
 	private function do_action_change_payment_method( $handle ) {
 		if ( ! empty( $_GET['token_id'] ) ) {
+			$token_id = sanitize_text_field( wp_unslash( $_GET['token_id'] ) );
 			reepay_s()->api()->request( "subscription/{$handle}/pm", 'POST', [
-				'source' => $_GET['token_id'],
+				'source' => $token_id,
 			] );
 		}
 	}

--- a/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
+++ b/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
@@ -48,9 +48,7 @@ class WC_Reepay_My_Account_Subscription_Actions {
 				$subscription = reepay_s()->api()->request( "subscription/{$subscription_handle}" );
 
 				// Security: Verify subscription ownership
-				if ( ! WC_Reepay_My_Account_Subscription_Page::customer_has_access_to_subscription( $subscription ) ) {
-					throw new Exception( __( 'You do not have permission to perform this action.', 'reepay-subscriptions-for-woocommerce' ) );
-				}
+				WC_Reepay_My_Account_Subscription_Page::customer_has_access_to_subscription( $subscription );
 
 				// Security: Use switch instead of call_user_func for better security
 				switch ( $subscription_action ) {
@@ -118,9 +116,18 @@ class WC_Reepay_My_Account_Subscription_Actions {
 				throw new Exception( __( 'Invalid token format.', 'reepay-subscriptions-for-woocommerce' ) );
 			}
 
-			// Security: Verify token belongs to current user
-			$token = WC_Payment_Tokens::get( $token_id );
-			if ( ! $token || $token->get_user_id() !== get_current_user_id() ) {
+			// Security: Verify token belongs to current user by matching against their saved WC tokens.
+			// token_id is a Reepay card ID (ca_...) stored as the WC token value — not a WC token numeric ID.
+			$user_tokens = WC_Payment_Tokens::get_customer_tokens( get_current_user_id() );
+			$token_owned = false;
+			foreach ( $user_tokens as $user_token ) {
+				if ( $user_token->get_token() === $token_id ) {
+					$token_owned = true;
+					break;
+				}
+			}
+
+			if ( ! $token_owned ) {
 				throw new Exception( __( 'Invalid payment method.', 'reepay-subscriptions-for-woocommerce' ) );
 			}
 

--- a/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
+++ b/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
@@ -15,13 +15,13 @@ class WC_Reepay_My_Account_Subscription_Actions {
 	}
 
 	public function do_action() {
-		// Security: Check user is logged in
-		if ( ! is_user_logged_in() ) {
-			wc_add_notice( __( 'You must be logged in to perform this action.', 'reepay-subscriptions-for-woocommerce' ), 'error' );
+		if ( ! isset( $_GET['reepay_subscriptions_action'] ) ) {
 			return;
 		}
 
-		if ( ! isset( $_GET['reepay_subscriptions_action'] ) ) {
+		// Security: Check user is logged in
+		if ( ! is_user_logged_in() ) {
+			wc_add_notice( __( 'You must be logged in to perform this action.', 'reepay-subscriptions-for-woocommerce' ), 'error' );
 			return;
 		}
 

--- a/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
+++ b/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
@@ -37,6 +37,13 @@ class WC_Reepay_My_Account_Subscription_Actions {
 
 			$subscription_handle = sanitize_text_field( $_GET[ $subscription_action ] );
 
+			// Security: Validate subscription handle format
+			if ( ! preg_match( '/^[a-zA-Z0-9_-]{1,64}$/', $subscription_handle ) ) {
+				wc_add_notice( __( 'Invalid subscription handle format.', 'reepay-subscriptions-for-woocommerce' ), 'error' );
+				wp_redirect( wc_get_endpoint_url( WC_Reepay_My_Account_Subscription_Page::$menu_item_slug ) );
+				exit();
+			}
+
 			try {
 				$subscription = reepay_s()->api()->request( "subscription/{$subscription_handle}" );
 
@@ -45,7 +52,26 @@ class WC_Reepay_My_Account_Subscription_Actions {
 					throw new Exception( __( 'You do not have permission to perform this action.', 'reepay-subscriptions-for-woocommerce' ) );
 				}
 
-				call_user_func( array( $this, "do_action_$subscription_action" ), $subscription_handle );
+				// Security: Use switch instead of call_user_func for better security
+				switch ( $subscription_action ) {
+					case 'cancel_subscription':
+						$this->do_action_cancel_subscription( $subscription_handle );
+						break;
+					case 'uncancel_subscription':
+						$this->do_action_uncancel_subscription( $subscription_handle );
+						break;
+					case 'put_on_hold':
+						$this->do_action_put_on_hold( $subscription_handle );
+						break;
+					case 'reactivate':
+						$this->do_action_reactivate( $subscription_handle );
+						break;
+					case 'change_payment_method':
+						$this->do_action_change_payment_method( $subscription_handle );
+						break;
+					default:
+						throw new Exception( __( 'Invalid subscription action.', 'reepay-subscriptions-for-woocommerce' ) );
+				}
 			} catch ( Exception $exception ) {
 				reepay_s()->log()->log(array(
 					'source' => 'WC_Reepay_My_Account_Subscription_Page::do_action',

--- a/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
+++ b/includes/my-account/WC_Reepay_My_Account_Subscription_Actions.php
@@ -15,6 +15,12 @@ class WC_Reepay_My_Account_Subscription_Actions {
 	}
 
 	public function do_action() {
+		// Security: Check user is logged in
+		if ( ! is_user_logged_in() ) {
+			wc_add_notice( __( 'You must be logged in to perform this action.', 'reepay-subscriptions-for-woocommerce' ), 'error' );
+			return;
+		}
+
 		if ( ! isset( $_GET['reepay_subscriptions_action'] ) ) {
 			return;
 		}
@@ -29,11 +35,16 @@ class WC_Reepay_My_Account_Subscription_Actions {
 				continue;
 			}
 
-			$subscription_handle = urlencode( sanitize_text_field( $_GET[ $subscription_action ] ) );
+			$subscription_handle = sanitize_text_field( $_GET[ $subscription_action ] );
 
 			try {
 				$subscription = reepay_s()->api()->request( "subscription/{$subscription_handle}" );
-				WC_Reepay_My_Account_Subscription_Page::customer_has_access_to_subscription( $subscription );
+
+				// Security: Verify subscription ownership
+				if ( ! WC_Reepay_My_Account_Subscription_Page::customer_has_access_to_subscription( $subscription ) ) {
+					throw new Exception( __( 'You do not have permission to perform this action.', 'reepay-subscriptions-for-woocommerce' ) );
+				}
+
 				call_user_func( array( $this, "do_action_$subscription_action" ), $subscription_handle );
 			} catch ( Exception $exception ) {
 				reepay_s()->log()->log(array(
@@ -75,6 +86,18 @@ class WC_Reepay_My_Account_Subscription_Actions {
 	private function do_action_change_payment_method( $handle ) {
 		if ( ! empty( $_GET['token_id'] ) ) {
 			$token_id = sanitize_text_field( wp_unslash( $_GET['token_id'] ) );
+
+			// Security: Validate token format (alphanumeric, dashes, underscores only)
+			if ( ! preg_match( '/^[a-zA-Z0-9_-]{10,64}$/', $token_id ) ) {
+				throw new Exception( __( 'Invalid token format.', 'reepay-subscriptions-for-woocommerce' ) );
+			}
+
+			// Security: Verify token belongs to current user
+			$token = WC_Payment_Tokens::get( $token_id );
+			if ( ! $token || $token->get_user_id() !== get_current_user_id() ) {
+				throw new Exception( __( 'Invalid payment method.', 'reepay-subscriptions-for-woocommerce' ) );
+			}
+
 			reepay_s()->api()->request( "subscription/{$handle}/pm", 'POST', [
 				'source' => $token_id,
 			] );

--- a/includes/my-account/WC_Reepay_My_Account_Subscription_Page.php
+++ b/includes/my-account/WC_Reepay_My_Account_Subscription_Page.php
@@ -60,7 +60,7 @@ class WC_Reepay_My_Account_Subscription_Page {
 	}
 
 	public function get_customer_payment_methods( string $subscription_handle, string $customer_handle = '' ): array {
-		if ( empty( $customer ) ) {
+		if ( empty( $customer_handle ) ) {
 			$customer_handle = rp_get_customer_handle( get_current_user_id() );
 		}
 
@@ -106,7 +106,7 @@ class WC_Reepay_My_Account_Subscription_Page {
 	}
 
 	public static function customer_has_access_to_subscription( $subscription, $customer_handle = '' ) {
-		if ( empty( $customer ) ) {
+		if ( empty( $customer_handle ) ) {
 			$customer_handle = rp_get_customer_handle( get_current_user_id() );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, subscriptions, ecommerce, e-commerce, commerce
 Requires at least: 5.5
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 1.3.5
+Stable tag: 1.3.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -74,6 +74,9 @@ Standard Frisbii Billing features:
 3. For correct plugin operation install and activate Frisbii Pay for WooCommerce. API keys for both plugins should be the same.
 
 == Changelog ==
+v 1.3.6
+- [Improvement] - General security patches.
+
 v 1.3.5
 - [Fix] - various API-errors
 - [Improvement] - Gracefully handle order capture if products are deleted or inactive in WooCommerce

--- a/reepay-subscriptions-for-woocommerce.php
+++ b/reepay-subscriptions-for-woocommerce.php
@@ -347,7 +347,10 @@ class WooCommerce_Reepay_Subscriptions
 
     public function admin_customer_report()
     {
-        if (isset($_GET['path']) && $_GET['path'] == '/customers') {
+        // Security: Sanitize path parameter
+        $path = isset( $_GET['path'] ) ? sanitize_text_field( wp_unslash( $_GET['path'] ) ) : '';
+        
+        if ( $path === '/customers' ) {
             $script_path       = 'assets/js/analytics/build/index.js';
             $script_asset_path = $this->settings('plugin_url').'assets/js/analytics/build/index.asset.php';
             $script_asset      = file_exists($script_asset_path)

--- a/reepay-subscriptions-for-woocommerce.php
+++ b/reepay-subscriptions-for-woocommerce.php
@@ -1009,7 +1009,7 @@ class WooCommerce_Reepay_Subscriptions
                 $page      = get_post( $page_subscription_terms );
 
                 if ( $page && 'publish' === $page->post_status && $page->post_content && ! has_shortcode( $page->post_content, 'woocommerce_checkout' ) ) {
-                    echo '<div class="billwerk-optimize-terms-and-conditions" style="display: none; max-height: 200px; overflow: auto; padding: 1em; box-shadow: inset 0 1px 3px rgba(0, 0, 0, .2); margin-bottom: 16px;background-color: rgba(0, 0, 0, .05);">' . wc_format_content( $sanitizer->styled_post_content( $page->post_content ) ) . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    echo '<div class="billwerk-optimize-terms-and-conditions" style="display: none; max-height: 200px; overflow: auto; padding: 1em; box-shadow: inset 0 1px 3px rgba(0, 0, 0, .2); margin-bottom: 16px;background-color: rgba(0, 0, 0, .05);">' . wc_kses_post( $sanitizer->styled_post_content( $page->post_content ) ) . '</div>';
                 }
             }
 

--- a/reepay-subscriptions-for-woocommerce.php
+++ b/reepay-subscriptions-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Get all the advanced subscription features from Frisbii Billing while still keeping your usual WooCommerce tools. The Frisbii Billing for WooCommerce plugins gives you the best prerequisites to succeed with your subscription business.
  * Author: Frisbii
  * Author URI: https://frisbii.com
- * Version: 1.3.5
+ * Version: 1.3.6
  * Text Domain: reepay-subscriptions-for-woocommerce
  * Domain Path: /languages
  * WC requires at least: 3.0.0
@@ -55,7 +55,7 @@ class WooCommerce_Reepay_Subscriptions
     /**
      * @var string
      */
-    public static $version = '1.3.5';
+    public static $version = '1.3.6';
 
     /**
      * @var string
@@ -693,6 +693,7 @@ class WooCommerce_Reepay_Subscriptions
                 'get_addon'    => get_rest_url(0, reepay_s()->settings('rest_api_namespace')."/addon/"),
             ],
             'query_string' => !empty(get_option( 'permalink_structure' )) ? '?' : '&',
+            'nonce'                 => wp_create_nonce( 'wp_rest' ),
             'i18n'                  => $i18n
         ]);
     }

--- a/reepay-subscriptions-for-woocommerce.php
+++ b/reepay-subscriptions-for-woocommerce.php
@@ -904,6 +904,12 @@ class WooCommerce_Reepay_Subscriptions
      * Add subscripton terms value to meta data
      */
     public function subscription_terms_checkbox_order_meta($order_id){
+        // Security: Verify nonce (WooCommerce checkout process already validates this)
+        if ( ! isset( $_POST['woocommerce-process-checkout-nonce'] ) || 
+             ! wp_verify_nonce( $_POST['woocommerce-process-checkout-nonce'], 'woocommerce-process_checkout' ) ) {
+            return;
+        }
+        
         if (isset($_POST['subscription_terms'])) {
             $order = wc_get_order( $order_id );
             $order->update_meta_data( '_subscription_terms', sanitize_text_field($_POST['subscription_terms']) );
@@ -1053,6 +1059,7 @@ class WooCommerce_Reepay_Subscriptions
         if ( $has_reepay_product && !isset($_POST['subscription_terms']) ) {
             wc_add_notice(__('Please read and accept the subscription terms to proceed', 'reepay-subscriptions-for-woocommerce'), 'error');
         } else if ( $has_reepay_product && isset($_POST['subscription_terms']) ) {
+            // Security: Nonce verification (already done by WooCommerce for checkout process)
             // Save the subscription terms acceptance to order meta
             $order->update_meta_data( '_subscription_terms', sanitize_text_field($_POST['subscription_terms']) );
             $order->save();

--- a/templates/admin-addon-single-data.php
+++ b/templates/admin-addon-single-data.php
@@ -16,13 +16,13 @@ if ( empty( $addon['disabled'] ) ) {
 global $post;
 ?>
 <p class="form-field">
-    <label for="addon_name_<?php echo esc_html( $loop ); ?>">
+    <label for="addon_name_<?php echo esc_attr( $loop ); ?>">
 		<?php _e( 'Name', 'reepay-subscriptions-for-woocommerce' ); ?>
     </label>
     <span><?php echo esc_attr( $addon['name'] ) ?></span>
 </p>
 <p class="form-field">
-    <label for="addon_type_<?php echo esc_html( $loop ); ?>">
+    <label for="addon_type_<?php echo esc_attr( $loop ); ?>">
 		<?php _e( 'Type', 'reepay-subscriptions-for-woocommerce' ); ?>
     </label>
     <span>
@@ -35,7 +35,7 @@ global $post;
 </p>
 
 <p class="form-field">
-    <label for="addon_name_<?php echo esc_html( $loop ); ?>">
+    <label for="addon_name_<?php echo esc_attr( $loop ); ?>">
 		<?php
 		_e( 'Description', 'reepay-subscriptions-for-woocommerce' );
 		echo wc_help_tip( __( 'Will display on the frontend', 'reepay-subscriptions-for-woocommerce' ) );
@@ -45,14 +45,14 @@ global $post;
 </p>
 
 <p class="form-field">
-    <label for="addon_name_<?php echo esc_html( $loop ); ?>">
+    <label for="addon_name_<?php echo esc_attr( $loop ); ?>">
 		<?php _e( 'Amount (per unit)', 'reepay-subscriptions-for-woocommerce' ); ?>
     </label>
     <span><?php echo esc_attr( $addon['amount'] ) ?></span>
 </p>
 
 <p class="form-field">
-    <label for="addon_type_<?php echo esc_html( $loop ); ?>">
+    <label for="addon_type_<?php echo esc_attr( $loop ); ?>">
 		<?php _e( 'Add-on availability', 'reepay-subscriptions-for-woocommerce' ); ?>
     </label>
     <span>

--- a/templates/admin-addon-single.php
+++ b/templates/admin-addon-single.php
@@ -50,7 +50,7 @@ global $post;
 				<?php
 				if ( ! empty( $addons_list ) ): ?>
                     <select name="addon_choose_exist[<?php
-					echo $loop; ?>]"
+					echo esc_attr( $loop ); ?>]"
                             class="wc_input_subscription_period_interval js-subscription_choose_exist">
                         <option value=""><?php
 							_e( 'Select add-on', 'reepay-subscriptions-for-woocommerce' ); ?></option>

--- a/templates/admin-addons-panel.php
+++ b/templates/admin-addons-panel.php
@@ -142,7 +142,9 @@
 							reepay_s()->settings( 'rest_api_namespace' ) . "/addon/" ) . reepay_s()->settings( 'query_string' ) . 'product_id=' . ( intval( $_GET['post'] ?? 0 ) ) ?>' + `&handle=${handle}`,
                     method: 'GET',
                     beforeSend: function (xhr) {
-
+                        if (window.reepay && window.reepay.nonce) {
+                            xhr.setRequestHeader('X-WP-Nonce', window.reepay.nonce);
+                        }
                     },
                     success: function (response_data) {
                         if (!response_data.success) {

--- a/templates/discounts-and-coupons-fields-data-coupon.php
+++ b/templates/discounts-and-coupons-fields-data-coupon.php
@@ -33,7 +33,7 @@
 		if ( ! empty( $meta['_reepay_discount_eligible_plans'] ) ): ?>
 			<?php
 			foreach ( $meta['_reepay_discount_eligible_plans'][0] as $eligible_plan ) {
-				echo '<br>' . $eligible_plan;
+				echo '<br>' . esc_html( $eligible_plan );
 			} ?>
 		<?php
 		endif; ?>

--- a/templates/discounts-and-coupons-fields-data-discount.php
+++ b/templates/discounts-and-coupons-fields-data-discount.php
@@ -36,7 +36,7 @@
             <input disabled type="checkbox" id="<?php echo esc_attr( $value ) ?>"
                    name="_reepay_discount_apply_to_items[]"
                    required
-				<?php echo $is_update ? 'disabled="disabled"' : '' ?>
+				<?php disabled( $is_update, true ); ?>
                    value="<?php echo esc_attr( $value ) ?>" <?php checked( in_array( $value, $meta['_reepay_discount_apply_to_items'][0] ?? [] ), true ); ?>/> &nbsp<?php esc_html_e( $label, 'reepay-subscriptions-for-woocommerce' ); ?>
             &nbsp
 		<?php endforeach; ?>

--- a/templates/import/checkbox.php
+++ b/templates/import/checkbox.php
@@ -6,6 +6,6 @@
 ?>
 
 <label>
-    <input type="<?php echo $args['input_type'] ?? 'checkbox' ?>"
-           name="reepay_import<?php echo $args['option_name'] ?>"/>
+    <input type="<?php echo esc_attr( $args['input_type'] ?? 'checkbox' ) ?>"
+           name="reepay_import<?php echo esc_attr( $args['option_name'] ) ?>"/>
 </label>

--- a/templates/import/page.php
+++ b/templates/import/page.php
@@ -1,5 +1,5 @@
 <div class="wrap">
-    <h1><?php echo get_admin_page_title() ?></h1>
+    <h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
     <?php
     wc_get_template(

--- a/templates/myaccount/my-subscription-error.php
+++ b/templates/myaccount/my-subscription-error.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="woocommerce_account_subscriptions">
     <p class="no_subscriptions woocommerce-message woocommerce-message--info woocommerce-Message woocommerce-Message--info woocommerce-info">
-		<?php echo $error; ?>
+		<?php echo esc_html( $error ); ?>
 
 		<?php if ( ! empty( $show_return_to_shop_btn ) ) : ?>
             <a class="woocommerce-Button button"

--- a/templates/myaccount/my-subscription.php
+++ b/templates/myaccount/my-subscription.php
@@ -12,6 +12,9 @@
 		exit; // Exit if accessed directly.
 	}
 
+	// Security: Generate nonce for subscription actions
+	$subscription_nonce = wp_create_nonce( 'reepay_subscription_action' );
+
 ?>
 <table class="shop_table subscription_details">
     <tbody>
@@ -21,7 +24,7 @@
     </tr>
     <tr>
         <td><?php esc_html_e( 'Plan', 'reepay-subscriptions-for-woocommerce' ); ?></td>
-        <td><?php echo ucfirst( $plan['name'] ) ?>
+        <td><?php echo esc_html( ucfirst( $plan['name'] ) ); ?>
         </td>
     </tr>
 
@@ -40,15 +43,15 @@
                 <td><?php _e( 'Actions:', 'reepay-subscriptions-for-woocommerce' ); ?></td>
                 <td>
 					<?php if ( $subscription['state'] === 'on_hold' ): ?>
-                        <a href="?reepay_subscriptions_action&reactivate=<?php echo esc_attr( $subscription['handle'] ) ?>" class="button"><?php _e( 'Reactivate', 'reepay-subscriptions-for-woocommerce' ); ?></a>
+                        <a href="?reepay_subscriptions_action&reactivate=<?php echo esc_attr( $subscription['handle'] ); ?>&_wpnonce=<?php echo esc_attr( $subscription_nonce ); ?>" class="button"><?php _e( 'Reactivate', 'reepay-subscriptions-for-woocommerce' ); ?></a>
 					<?php else: ?><?php if ( reepay_s()->settings( '_reepay_enable_on_hold' ) ): ?>
-                        <a href="?reepay_subscriptions_action&put_on_hold=<?php echo esc_attr( $subscription['handle'] ) ?>" class="button"><?php _e( 'Put on hold', 'reepay-subscriptions-for-woocommerce' ); ?></a>
+                        <a href="?reepay_subscriptions_action&put_on_hold=<?php echo esc_attr( $subscription['handle'] ); ?>&_wpnonce=<?php echo esc_attr( $subscription_nonce ); ?>" class="button"><?php _e( 'Put on hold', 'reepay-subscriptions-for-woocommerce' ); ?></a>
 					<?php endif; ?><?php endif; ?>
 
 					<?php if ( $subscription['state'] !== 'on_hold' ): ?><?php if ( $subscription['is_cancelled'] === true ): ?>
-                        <a href="?reepay_subscriptions_action&uncancel_subscription=<?php echo esc_attr( $subscription['handle'] ) ?>" class="button"><?php _e( 'Uncancel', 'reepay-subscriptions-for-woocommerce' ); ?></a>
+                        <a href="?reepay_subscriptions_action&uncancel_subscription=<?php echo esc_attr( $subscription['handle'] ); ?>&_wpnonce=<?php echo esc_attr( $subscription_nonce ); ?>" class="button"><?php _e( 'Uncancel', 'reepay-subscriptions-for-woocommerce' ); ?></a>
 					<?php else: ?><?php if ( reepay_s()->settings( '_reepay_enable_cancel' ) ): ?>
-                        <a href="?reepay_subscriptions_action&cancel_subscription=<?php echo esc_attr( $subscription['handle'] ) ?>" class="button"><?php _e( 'Cancel Subscription', 'reepay-subscriptions-for-woocommerce' ); ?></a>
+                        <a href="?reepay_subscriptions_action&cancel_subscription=<?php echo esc_attr( $subscription['handle'] ); ?>&_wpnonce=<?php echo esc_attr( $subscription_nonce ); ?>" class="button"><?php _e( 'Cancel Subscription', 'reepay-subscriptions-for-woocommerce' ); ?></a>
 					<?php endif; ?><?php endif; ?><?php endif; ?>
                 </td>
             </tr>
@@ -68,7 +71,7 @@
 							<?php if ( ! empty($payment_methods['current']) && $payment_methods['current']['id'] === $card['id'] ): ?>
                                 <?php _e( 'Current card', 'reepay-subscriptions-for-woocommerce' ); ?>
                             <?php else: ?>
-                                <a href="?reepay_subscriptions_action&change_payment_method=<?php echo esc_attr( $subscription['handle'] ); ?>&token_id=<?php echo esc_attr( $card['id'] ); ?>" class="button">
+                                <a href="?reepay_subscriptions_action&change_payment_method=<?php echo esc_attr( $subscription['handle'] ); ?>&token_id=<?php echo esc_attr( $card['id'] ); ?>&_wpnonce=<?php echo esc_attr( $subscription_nonce ); ?>" class="button">
                                     <?php _e( 'Use this card', 'reepay-subscriptions-for-woocommerce' ); ?>
                                 </a>
 							<?php endif; ?>
@@ -83,7 +86,7 @@
 							<?php if ( ! empty($payment_methods['current']) && $payment_methods['current']['id'] === $mps['id'] ): ?>
 								<?php _e( 'Current payment method', 'reepay-subscriptions-for-woocommerce' ); ?>
 							<?php else: ?>
-                                <a href="?reepay_subscriptions_action&change_payment_method=<?php echo esc_attr( $subscription['handle'] ); ?>&token_id=<?php echo esc_attr( $mps['id'] ); ?>" class="button">
+                                <a href="?reepay_subscriptions_action&change_payment_method=<?php echo esc_attr( $subscription['handle'] ); ?>&token_id=<?php echo esc_attr( $mps['id'] ); ?>&_wpnonce=<?php echo esc_attr( $subscription_nonce ); ?>" class="button">
 									<?php _e( 'Use this payment method', 'reepay-subscriptions-for-woocommerce' ); ?>
                                 </a>
 							<?php endif; ?>
@@ -94,7 +97,7 @@
             <tr>
                 <td></td>
                 <td>
-                    <a href="<?php echo wc_get_endpoint_url( 'add-payment-method' ) . '?reepay_subscription=' . esc_attr( $subscription['handle'] ) ?>" class="button">
+                    <a href="<?php echo esc_url( wp_nonce_url( wc_get_endpoint_url( 'add-payment-method' ) . '?reepay_subscription=' . esc_attr( $subscription['handle'] ), 'reepay_add_payment_method', '_wpnonce' ) ); ?>" class="button">
 						<?php _e( 'Add payment method', 'reepay-subscriptions-for-woocommerce' ); ?>
                     </a>
                 </td>

--- a/templates/myaccount/my-subscription.php
+++ b/templates/myaccount/my-subscription.php
@@ -63,7 +63,7 @@
 					[ $month, $year ] = explode( '-', $card['exp_date'] );
 					?>
                     <tr>
-                        <td><?php echo $card['masked_card'] ?> <?php echo "$month/$year" ?></td>
+                        <td><?php echo esc_html( $card['masked_card'] ) ?> <?php echo esc_html( "$month/$year" ) ?></td>
                         <td>
 							<?php if ( ! empty($payment_methods['current']) && $payment_methods['current']['id'] === $card['id'] ): ?>
                                 <?php _e( 'Current card', 'reepay-subscriptions-for-woocommerce' ); ?>
@@ -78,7 +78,7 @@
 				<?php foreach ( $payment_methods['mps_subscriptions'] as $mps ):
 					?>
                     <tr>
-                        <td><?php echo $mps['id'] ?></td>
+                        <td><?php echo esc_html( $mps['id'] ) ?></td>
                         <td>
 							<?php if ( ! empty($payment_methods['current']) && $payment_methods['current']['id'] === $mps['id'] ): ?>
 								<?php _e( 'Current payment method', 'reepay-subscriptions-for-woocommerce' ); ?>

--- a/templates/myaccount/my-subscription.php
+++ b/templates/myaccount/my-subscription.php
@@ -68,7 +68,7 @@
 							<?php if ( ! empty($payment_methods['current']) && $payment_methods['current']['id'] === $card['id'] ): ?>
                                 <?php _e( 'Current card', 'reepay-subscriptions-for-woocommerce' ); ?>
                             <?php else: ?>
-                                <a href="?reepay_subscriptions_action&change_payment_method=<?php _e( $subscription['handle'] ) ?>&token_id=<?php esc_html_e( $card['id'] ) ?>" class="button">
+                                <a href="?reepay_subscriptions_action&change_payment_method=<?php echo esc_attr( $subscription['handle'] ); ?>&token_id=<?php echo esc_attr( $card['id'] ); ?>" class="button">
                                     <?php _e( 'Use this card', 'reepay-subscriptions-for-woocommerce' ); ?>
                                 </a>
 							<?php endif; ?>
@@ -83,7 +83,7 @@
 							<?php if ( ! empty($payment_methods['current']) && $payment_methods['current']['id'] === $mps['id'] ): ?>
 								<?php _e( 'Current payment method', 'reepay-subscriptions-for-woocommerce' ); ?>
 							<?php else: ?>
-                                <a href="?reepay_subscriptions_action&change_payment_method=<?php _e( $subscription['handle'] ) ?>&token_id=<?php esc_html_e( $mps['id'] ) ?>" class="button">
+                                <a href="?reepay_subscriptions_action&change_payment_method=<?php echo esc_attr( $subscription['handle'] ); ?>&token_id=<?php echo esc_attr( $mps['id'] ); ?>" class="button">
 									<?php _e( 'Use this payment method', 'reepay-subscriptions-for-woocommerce' ); ?>
                                 </a>
 							<?php endif; ?>

--- a/templates/myaccount/my-subscriptions-error.php
+++ b/templates/myaccount/my-subscriptions-error.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="woocommerce_account_subscriptions">
     <p class="no_subscriptions woocommerce-message woocommerce-message--info woocommerce-Message woocommerce-Message--info woocommerce-info">
-		<?php echo $error; ?>
+		<?php echo esc_html( $error ); ?>
 
 		<?php if ( ! empty( $show_return_to_shop_btn ) ) : ?>
             <a class="woocommerce-Button button"

--- a/templates/myaccount/my-subscriptions.php
+++ b/templates/myaccount/my-subscriptions.php
@@ -49,7 +49,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                 </td>
                 <td class="subscription-total order-total woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-total woocommerce-orders-table__cell-order-total"
                     data-title="<?php echo esc_attr_x( 'Total', 'Used in data attribute. Escaped', 'reepay-subscriptions-for-woocommerce' ); ?>">
-	                <?php echo esc_html( $subscription['amount'] . ' / ' . $subscription['billing_period'] ) ?>
+	                <?php echo wp_kses_post( $subscription['amount'] ) . ' / ' . esc_html( $subscription['billing_period'] ) ?>
                 </td>
                 <td class="subscription-actions order-actions woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-actions woocommerce-orders-table__cell-order-actions">
                     <a href="<?php echo esc_url( $subscription['link'] ) ?>"

--- a/templates/myaccount/my-subscriptions.php
+++ b/templates/myaccount/my-subscriptions.php
@@ -49,7 +49,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                 </td>
                 <td class="subscription-total order-total woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-total woocommerce-orders-table__cell-order-total"
                     data-title="<?php echo esc_attr_x( 'Total', 'Used in data attribute. Escaped', 'reepay-subscriptions-for-woocommerce' ); ?>">
-	                <?php echo $subscription['amount'] . ' / ' . $subscription['billing_period'] ?>
+	                <?php echo esc_html( $subscription['amount'] . ' / ' . $subscription['billing_period'] ) ?>
                 </td>
                 <td class="subscription-actions order-actions woocommerce-orders-table__cell woocommerce-orders-table__cell-subscription-actions woocommerce-orders-table__cell-order-actions">
                     <a href="<?php echo esc_url( $subscription['link'] ) ?>"

--- a/templates/plan-subscription-fields-data.php
+++ b/templates/plan-subscription-fields-data.php
@@ -11,7 +11,7 @@ if ( empty( $post ) ) {
 <div class="options_group reepay_subscription_pricing show_if_reepay_subscription">
     <p class="form-field">
         <label for="#"><?php _e( 'Price', 'reepay-subscriptions-for-woocommerce' ); ?></label>
-        <span><?php echo ( ! empty( $_reepay_subscription_price ) ? esc_attr( $_reepay_subscription_price ) : 0 ) . ' ' . $_reepay_subscription_currency ?></span>
+        <span><?php echo esc_html( ( ! empty( $_reepay_subscription_price ) ? $_reepay_subscription_price : 0 ) . ' ' . $_reepay_subscription_currency ) ?></span>
     </p>
 
     <p class="form-field">
@@ -50,13 +50,13 @@ if ( empty( $post ) ) {
 
         <p class="form-field">
             <label for="#"><?php _e( 'Charge every', 'reepay-subscriptions-for-woocommerce' ); ?></label>
-            <span><?php echo $month_data['month'] ?></span>
+            <span><?php echo esc_html( $month_data['month'] ) ?></span>
             <span><?php _e( 'Month', 'reepay-subscriptions-for-woocommerce' ); ?></span>
         </p>
 		<?php if ( ! empty( $month_data['day'] ) ) : ?>
             <p class="form-field">
                 <label for="#"><?php _e( 'On this day of the month', 'reepay-subscriptions-for-woocommerce' ); ?></label>
-                <span><?php echo $month_data['day'] ?></span>
+                <span><?php echo esc_html( $month_data['day'] ) ?></span>
             </p>
         <?php endif; ?>
         <p class="form-field">
@@ -166,7 +166,7 @@ if ( empty( $post ) ) {
 	<?php if ( $_reepay_subscription_schedule_type === WC_Reepay_Subscription_Plan_Simple::TYPE_WEEKLY_FIXED_DAY ) : ?>
         <p class="form-field">
             <label for="#"><?php _e( 'Charge every', 'reepay-subscriptions-for-woocommerce' ); ?></label>
-            <span><?php echo $_reepay_subscription_weekly_fixedday['week'] ?></span>
+            <span><?php echo esc_html( $_reepay_subscription_weekly_fixedday['week'] ) ?></span>
             <span><?php _e( 'Week', 'reepay-subscriptions-for-woocommerce' ); ?></span>
         </p>
         <p class="form-field">
@@ -247,7 +247,7 @@ if ( empty( $post ) ) {
 		<?php if ( ! empty( $_reepay_subscription_fee['enabled'] ) ) : ?>
             <p class="form-field">
                 <label for="#"><?php _e( 'Setup fee', 'reepay-subscriptions-for-woocommerce' ); ?></label>
-                <span><?php echo ( ! empty( $_reepay_subscription_fee['amount'] ) ? esc_attr( $_reepay_subscription_fee['amount'] ) : 0 ) . ' ' . $_reepay_subscription_currency ?></span>
+                <span><?php echo esc_html( ( ! empty( $_reepay_subscription_fee['amount'] ) ? $_reepay_subscription_fee['amount'] : 0 ) . ' ' . $_reepay_subscription_currency ) ?></span>
             </p>
             <p class="form-field">
                 <label for="#"><?php _e( 'Text', 'reepay-subscriptions-for-woocommerce' ); ?></label>
@@ -278,7 +278,7 @@ if ( empty( $post ) ) {
             if ( $_reepay_subscription_trial['type'] != 'customize' ) {
 	           _e( WC_Reepay_Subscription_Plan_Simple::$trial[ $_reepay_subscription_trial['type'] ], 'reepay-subscriptions-for-woocommerce' );
             } else {
-	           echo $_reepay_subscription_trial['length'] . ' ' . $_reepay_subscription_trial['unit'];
+	           echo esc_html( $_reepay_subscription_trial['length'] . ' ' . $_reepay_subscription_trial['unit'] );
             }
             ?>
         </span>

--- a/templates/plan-subscription-fields-data.php
+++ b/templates/plan-subscription-fields-data.php
@@ -22,7 +22,7 @@ if ( empty( $post ) ) {
 	<?php if ( $_reepay_subscription_schedule_type === WC_Reepay_Subscription_Plan_Simple::TYPE_DAILY ) : ?>
         <p class="form-field">
             <label for="#"><?php _e( 'Charge every', 'reepay-subscriptions-for-woocommerce' ); ?></label>
-            <span><?php echo ! empty( $_reepay_subscription_daily ) ? $_reepay_subscription_daily . ' ' . __( 'Days', 'reepay-subscriptions-for-woocommerce' ) : __( 'Day', 'reepay-subscriptions-for-woocommerce' ) ?></span>
+            <span><?php echo esc_html( ! empty( $_reepay_subscription_daily ) ? $_reepay_subscription_daily . ' ' . __( 'Days', 'reepay-subscriptions-for-woocommerce' ) : __( 'Day', 'reepay-subscriptions-for-woocommerce' ) ); ?></span>
         </p>
 	<?php endif; ?>
 
@@ -61,11 +61,11 @@ if ( empty( $post ) ) {
         <?php endif; ?>
         <p class="form-field">
             <label for="#"><?php _e( 'Partial period handling', 'reepay-subscriptions-for-woocommerce' ); ?></label>
-            <span><?php echo WC_Reepay_Subscription_Plan_Simple::$bill_types[ $month_data['period'] ?? '' ] ?? '' ?></span>
+            <span><?php echo esc_html( WC_Reepay_Subscription_Plan_Simple::$bill_types[ $month_data['period'] ?? '' ] ?? '' ); ?></span>
         </p>
         <p class="form-field">
             <label for="#"><?php _e( 'Proration setting', 'reepay-subscriptions-for-woocommerce' ); ?>: </label>
-            <span><?php echo WC_Reepay_Subscription_Plan_Simple::$proration_types[ $month_data['proration'] ?? '' ] ?? '' ?></span>
+            <span><?php echo esc_html( WC_Reepay_Subscription_Plan_Simple::$proration_types[ $month_data['proration'] ?? '' ] ?? '' ); ?></span>
         </p>
         <p class="form-field">
             <label for="#"><?php _e( 'Minimum prorated amount', 'reepay-subscriptions-for-woocommerce' ); ?></label>

--- a/templates/plan-subscription-plans-select.php
+++ b/templates/plan-subscription-plans-select.php
@@ -3,7 +3,7 @@
 $loop = isset($loop) ? "[$loop]" : '';
 ?>
 
-<select name="_reepay_subscription_handle<?php echo $loop ?>"
+<select name="_reepay_subscription_handle<?php echo esc_attr( $loop ) ?>"
         class="wc_input_subscription_period_interval select2"
 	<?php if ( isset( $data_plan ) ) : ?>
 		data-plan='<?php echo esc_html( $data_plan ) ?>'

--- a/templates/plan-subscription-plans-select.php
+++ b/templates/plan-subscription-plans-select.php
@@ -6,7 +6,7 @@ $loop = isset($loop) ? "[$loop]" : '';
 <select name="_reepay_subscription_handle<?php echo esc_attr( $loop ) ?>"
         class="wc_input_subscription_period_interval select2"
 	<?php if ( isset( $data_plan ) ) : ?>
-		data-plan='<?php echo esc_html( $data_plan ) ?>'
+		data-plan='<?php echo esc_attr( $data_plan ) ?>'
 	<?php endif; ?>>
 
 	<option value="">


### PR DESCRIPTION
v 1.3.6
- [Improvement] - General security patches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-critical request validation (nonces/permissions) across REST, AJAX, and account actions, which could block legitimate requests if nonces/capabilities aren’t present or expected formats differ.
> 
> **Overview**
> Bumps the plugin to **v1.3.6** and applies **general security hardening** across admin, REST, AJAX, and My Account flows.
> 
> Admin JS now sends the WP REST nonce (`X-WP-Nonce`) on REST calls (including converting a `$.get` to `$.ajax`), and the plugin localizes a REST nonce into `window.reepay`. REST endpoints tighten access by requiring `manage_woocommerce`, and multiple handlers now sanitize/escape inputs/outputs (e.g., `absint()` for `order_id`, `esc_html`/`esc_attr` in REST HTML and templates).
> 
> My Account subscription actions now require login + a dedicated nonce, validate subscription handles/token IDs, and verify payment method ownership before changing a subscription’s payment method; related payment-method URL/query handling is sanitized. Coupon saving and import AJAX endpoints add capability/nonce checks, sanitize request data, and replace dynamic `call_user_func` dispatch with explicit `switch` routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c446fc800ab6da0402c66187a57725617fbc8f75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->